### PR TITLE
Update Copilot instructions to use French for reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,6 @@
+>[!IMPORTANT]
+>Toutes les revues de code, explications et commentaires générés doivent être rédigés exclusivement en français, quel que soit le langage utilisé dans le code source.
+
 # Upply — Copilot Instructions (Backend)
 
 ## Conventions obligatoires


### PR DESCRIPTION
Add a note to write all code reviews and comments in French.